### PR TITLE
Update frontend.yaml to point acs config to acs-ui repo

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -100,23 +100,9 @@ objects:
                   title: Advanced Cluster Management
                   href: https://catalog.redhat.com/software/container-stacks/detail/5ec54aa3535cb70ab8c02996
                   isExternal: true
-                - id: acs-section
-                  title: Advanced Cluster Security
-                  expandable: true
-                  routes:
-                    - id: clusterOverview
-                      title: Overview
-                      href: /openshift/acs/overview
-                    - id: acs-getting-started
-                      title: Getting Started
-                      href: /openshift/acs/getting-started 
-                    - id: acs-instances
-                      title: ACS Instances
-                      href: /openshift/acs/instances
-                    - id: clusters-documentation
-                      title: Documentation
-                      href: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes
-                      isExternal: true
+                - segmentRef:
+                    segmentId: acs
+                    frontendName: acs
                 - id: openshift-ai
                   title: OpenShift AI
                   expandable: true


### PR DESCRIPTION
# Summary

References the [acs-ui repository](https://github.com/RedHatInsights/acs-ui/blob/main/deploy/frontend.yaml#L20) configuration for the navigation section "Advanced Cluster Security" at console.redhat.com. This pattern is similar to what is being done for `cost-management` in the same frontend.yaml file.

Discussion thread: https://redhat-internal.slack.com/archives/C023VGW21NU/p1757694022226329
Parent Jira: https://issues.redhat.com/browse/ROX-28827
Link to PR marking ACS as `feoReplacement` in staging: (TODO)

# Jira

One of the steps needed to complete the ACS FEO migration https://issues.redhat.com/browse/ROX-28827

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

The ACS navigation pages should be visible in the staging console https://console.dev.redhat.com/openshift/acs/overview

# Screen Captures

NA

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
